### PR TITLE
chore: Add Commitizen configuration for conventional commits and versioning

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -1,0 +1,9 @@
+[tool.commitizen]
+name = "cz_conventional_commits"
+tag_format = "v$version"
+version_scheme = "semver2"
+version = "1.0.0"
+update_changelog_on_bump = true
+version_files = [
+	"build.gradle.kts:version"
+]

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,81 +34,43 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew test
 
-  determine-version:
+  bump-version:
     runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.semantic_version.outputs.version }}
-      previous_version: ${{ steps.semantic_version.outputs.previous_version }}
-      version_type: ${{ steps.semantic_version.outputs.version_type }}
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Semantic Versioning
-        id: semantic_version
-        uses: paulhatch/semantic-version@v5.4.0
-
-  release:
-    runs-on: ubuntu-latest
-    needs: [ test, determine-version ]
-    if: inputs.publishOnly == false && needs.determine-version.outputs.version_type != 'none'
+    needs: test
+    if: inputs.publishOnly == false
     permissions:
       contents: write
+      issues: write
+    outputs:
+      version: ${{ env.REVISION }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
+          fetch-tags: 'true'
           fetch-depth: 0
 
-      - name: Create new tagged release
-        run: |
-          # Set up Git user
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "8130295+github-actions[bot]@users.noreply.github.com"
-
-          # Update version in build.gradle.kts
-          sed -i 's/version = ".*"/version = "${{ needs.determine-version.outputs.version }}"/' build.gradle.kts
-          git add build.gradle.kts
-          git commit -m "chore: bump version to ${{ needs.determine-version.outputs.version }}"
-          git push origin main
-
-          # Create a new tag
-          git tag v${{ needs.determine-version.outputs.version }}
-          git push origin v${{ needs.determine-version.outputs.version }}
-
-      - name: Update CHANGELOG
-        id: changelog
-        uses: requarks/changelog-action@v1
+      - name: Create bump and changelog
+        uses: commitizen-tools/commitizen-action@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          fromTag: v${{ needs.determine-version.outputs.version }}
-          toTag: v${{ needs.determine-version.outputs.previous_version }}
-          writeToFile: false
-
-      - name: Generate GitHub Release Notes
-        uses: ncipollo/release-action@v1
-        with:
-          generateReleaseNotes: true
-          tag: v${{ needs.determine-version.outputs.version }}
-          body: ${{ steps.changelog.outputs.changes }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
   publish:
     runs-on: ubuntu-latest
-    needs: [ release, determine-version ]
+    needs:
+      - test
+      - bump-version
     permissions:
       contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: v${{ needs.determine-version.outputs.version }}
+          ref: v${{ needs.bump-version.outputs.version }}
 
       - uses: actions/setup-java@v4
         with:
-          distribution: temurin
+          distribution: corretto
           java-version: 21
 
       - name: Gradle Wrapper Validation


### PR DESCRIPTION
This pull request introduces changes to streamline the versioning and release process by integrating `Commitizen` for semantic versioning and simplifying the GitHub Actions workflow. The modifications include adding a `commitizen` configuration file and refactoring the release workflow to use `commitizen-action` for version bumps and changelog updates.

### Versioning and Configuration Updates:
* Added a new `commitizen` configuration file (`.cz.toml`) to enable semantic versioning with `Commitizen`, specifying the versioning scheme as `semver2` and linking the version to `build.gradle.kts`.

### GitHub Actions Workflow Refactor:
* Replaced the `determine-version` and `release` jobs with a unified `bump-version` job that uses `commitizen-action` for version bumping and changelog generation, reducing complexity in the workflow.
* Updated the `publish` job to depend on the new `bump-version` job and adjusted the Java distribution to `corretto` with version 21 for compatibility.