### PR TITLE
ci: Update Commitizen action to use the latest master version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,7 +51,7 @@ jobs:
           fetch-depth: 0
 
       - name: Create bump and changelog
-        uses: commitizen-tools/commitizen-action@v4
+        uses: commitizen-tools/commitizen-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration to ensure compatibility with the latest version of the `commitizen-action` GitHub Action.

Workflow configuration update:

* [`.github/workflows/release.yaml`](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL54-R54): Updated the `commitizen-action` GitHub Action from version `v4` to `master` in the "Create bump and changelog" step to use the latest version of the action.