### PR TITLE
ci: Update GitHub Actions to use PAT_AVRO_TOKEN for commitizen action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: Create bump and changelog
         uses: commitizen-tools/commitizen-action@master
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.PAT_AVRO_TOKEN }}
 
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for the release process by modifying the authentication token used in the `Create bump and changelog` step.

Authentication update:

* [`.github/workflows/release.yaml`](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL56-R56): Changed the `github_token` from `${{ secrets.GITHUB_TOKEN }}` to `${{ secrets.PAT_AVRO_TOKEN }}` in the `Create bump and changelog` step to use a different token for authentication.